### PR TITLE
Upgrade pip and use headless opencv in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get -y install \
     && rm -rf /var/lib/apt/lists/*
 
 # install python dependencies
+RUN pip3 install --upgrade pip
 RUN pip3 install torch~=1.8 torchvision opencv-python~=3.4 timm
 
 # copy inference code

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get -y install \
 
 # install python dependencies
 RUN pip3 install --upgrade pip
-RUN pip3 install torch~=1.8 torchvision opencv-python~=3.4 timm
+RUN pip3 install torch~=1.8 torchvision opencv-python-headless~=3.4 timm
 
 # copy inference code
 WORKDIR /opt/MiDaS


### PR DESCRIPTION
Currently, `docker build` fails with the following:

```
Step 3/9 : RUN pip3 install torch~=1.8 torchvision opencv-python~=3.4 timm
 ---> Running in d2650d3f25eb
Collecting torch~=1.8
  Downloading https://files.pythonhosted.org/packages/9a/f1/735e39ed0e3877ff02ffe625989bb421747c3dfd256e37ed92ad32c986be/torch-1.9.1-cp36-cp36m-manylinux1_x86_64.whl (831.4MB)
Collecting torchvision
  Downloading https://files.pythonhosted.org/packages/8e/3b/73e2cf095f0a9d0f26b008cbfc009512c53bb2a445723aaad54b33e58cb5/torchvision-0.10.1-cp36-cp36m-manylinux1_x86_64.whl (22.1MB)
Collecting opencv-python~=3.4
  Downloading https://files.pythonhosted.org/packages/d7/71/d5ac1ee0e9906a2edec2224da53e43f91291217a664c523219361db23395/opencv-python-3.4.15.55.tar.gz (87.7MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-9ye8pam0/opencv-python/setup.py", line 10, in <module>
        import skbuild
    ModuleNotFoundError: No module named 'skbuild'
```

This PR upgrades the pip version prior to installing opencv, which resolves the error (also observed in https://github.com/openvinotoolkit/dlstreamer_gst/issues/105 with same fix).

-----------------------------------

Edit: also installs opencv-python-headless to prevent an `ImportError` on libgl.

```
Step 9/10 : RUN python3 run.py --model_type dpt_hybrid; exit 0
 ---> Running in 07b4c047d90d
Traceback (most recent call last):
  File "run.py", line 6, in <module>
    import utils
  File "/opt/MiDaS/utils.py", line 6, in <module>
    import cv2
  File "/usr/local/lib/python3.6/dist-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```