### PR TITLE
Update README to specify version for timm

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The original model that was trained on 5 datasets  (`MIX 5` in the paper) can be
 
     ```shell
     conda install pytorch torchvision opencv
-    pip install timm
+    pip install timm==0.4.5
     ```
 
    The code was tested with Python 3.7, PyTorch 1.8.0, OpenCV 4.5.1, and timm 0.4.5.


### PR DESCRIPTION
At present, anyone following the instructions in the README
will end up with a codebase that can't actually run the
DPT-Hybrid model.