### PR TITLE
Fix usage of Next-ViT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ MiDaS 2.1: Legacy convolutional models [midas_v21_384](https://github.com/isl-or
 
 #### optional
 
-For the Next-ViT model, install
+For the Next-ViT model, execute
 
 ```shell
-./install_next_vit.sh
+git submodule add https://github.com/isl-org/Next-ViT midas/external/next_vit
 ```
 
 For the OpenVINO model, install

--- a/install_next_vit.sh
+++ b/install_next_vit.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-git clone https://github.com/bytedance/Next-ViT.git externals/Next_ViT

--- a/midas/backbones/next_vit.py
+++ b/midas/backbones/next_vit.py
@@ -5,9 +5,7 @@ import torch.nn as nn
 from pathlib import Path
 from .utils import activations, forward_default, get_activation
 
-file = open("./externals/Next_ViT/classification/nextvit.py", "r")
-source_code = file.read().replace(" utils", " externals.Next_ViT.classification.utils")
-exec(source_code)
+from ..external.next_vit.classification.nextvit import *
 
 
 def forward_next_vit(pretrained, x):

--- a/midas/blocks.py
+++ b/midas/blocks.py
@@ -18,10 +18,6 @@ from .backbones.swin2 import (
 from .backbones.swin import (
     _make_pretrained_swinl12_384,
 )
-from .backbones.next_vit import (
-    _make_pretrained_next_vit_large_6m,
-    forward_next_vit,
-)
 from .backbones.levit import (
     _make_pretrained_levit_384,
     forward_levit,
@@ -85,6 +81,7 @@ def _make_encoder(backbone, features, use_pretrained, groups=1, expand=False, ex
             [192, 384, 768, 1536], features, groups=groups, expand=expand
         )  # Swin-L/12 (backbone)
     elif backbone == "next_vit_large_6m":
+        from .backbones.next_vit import _make_pretrained_next_vit_large_6m
         pretrained = _make_pretrained_next_vit_large_6m(hooks=hooks)
         scratch = _make_scratch(
             in_features, features, groups=groups, expand=expand

--- a/midas/dpt_depth.py
+++ b/midas/dpt_depth.py
@@ -8,7 +8,6 @@ from .blocks import (
     _make_encoder,
     forward_beit,
     forward_swin,
-    forward_next_vit,
     forward_levit,
     forward_vit,
 )
@@ -90,6 +89,7 @@ class DPT(BaseModel):
         elif "swin" in backbone:
             self.forward_transformer = forward_swin
         elif "next_vit" in backbone:
+            from .backbones.next_vit import forward_next_vit
             self.forward_transformer = forward_next_vit
         elif "levit" in backbone:
             self.forward_transformer = forward_levit


### PR DESCRIPTION
  - make Next-ViT optional by importing from Next-ViT repo only if Next-ViT model is used
  - use git submodule to include Next-ViT as external dependency (credit to hafriedlander)
  - replace shell script by installation instruction in readme