### PR TITLE
Update base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # enables cuda support in docker
-FROM nvidia/cuda:10.2-cudnn7-runtime-ubuntu18.04
+FROM nvidia/cuda:12.0.1-cudnn8-runtime-ubuntu22.04
 
-# install python 3.6, pip and requirements for opencv-python 
+# install python 3.6, pip and requirements for opencv-python
 # (see https://github.com/NVIDIA/nvidia-docker/issues/864)
 RUN apt-get update && apt-get -y install \
     python3 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # enables cuda support in docker
 FROM nvidia/cuda:12.0.1-cudnn8-runtime-ubuntu22.04
 
-# install python 3.6, pip and requirements for opencv-python
+# install python 3, pip and requirements for opencv-python
 # (see https://github.com/NVIDIA/nvidia-docker/issues/864)
 RUN apt-get update && apt-get -y install \
     python3 \
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get -y install \
 
 # install python dependencies
 RUN pip3 install --upgrade pip
-RUN pip3 install torch~=1.8 torchvision opencv-python-headless~=3.4 timm
+RUN pip3 install torch~=1.8 torchvision opencv-python-headless~=3.4 timm imutils
 
 # copy inference code
 WORKDIR /opt/MiDaS


### PR DESCRIPTION
* Using `nvidia/cuda:12.0.1-cudnn8-runtime-ubuntu22.04` adds CUDA support for newer graphic chips.
* `imutils` popped up as a missing dependency for me.