### PR TITLE
Fix handling of filenames with non-ascii characters

### DIFF
--- a/run.py
+++ b/run.py
@@ -14,6 +14,8 @@ from imutils.video import VideoStream
 from midas.model_loader import default_models, load_model
 
 first_execution = True
+
+
 def process(device, model, model_type, image, input_size, target_size, optimize, use_camera):
     """
     Run the inference and interpolate.
@@ -142,8 +144,9 @@ def run(input_path, output_path, model_path, model_type="dpt_beit_large_512", op
         if output_path is None:
             print("Warning: No output path specified. Images will be processed but not shown or stored anywhere.")
         for index, image_name in enumerate(image_names):
+            image_name = image_name.encode('utf-8', 'surrogateescape').decode('utf-8')
 
-            print("  Processing {} ({}/{})".format(image_name, index + 1, num_images))
+            print("  Processing {} ({}/{})".format(image_name.encode('utf-8'), index + 1, num_images))
 
             # input
             original_image_rgb = utils.read_image(image_name)  # in [0, 1]
@@ -263,7 +266,6 @@ if __name__ == "__main__":
                         )
 
     args = parser.parse_args()
-
 
     if args.model_weights is None:
         args.model_weights = default_models[args.model_type]

--- a/utils.py
+++ b/utils.py
@@ -65,7 +65,7 @@ def write_pfm(path, image, scale=1):
         scale (int, optional): Scale. Defaults to 1.
     """
 
-    with open(path, "wb") as file:
+    with open(path.encode('utf-8'), "wb") as file:
         color = None
 
         if image.dtype.name != "float32":
@@ -163,6 +163,7 @@ def resize_depth(depth, width, height):
 
     return depth_resized
 
+
 def write_depth(path, depth, grayscale, bits=1):
     """Write depth map to png file.
 
@@ -175,7 +176,7 @@ def write_depth(path, depth, grayscale, bits=1):
         bits = 1
 
     if not np.isfinite(depth).all():
-        depth=np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
+        depth = np.nan_to_num(depth, nan=0.0, posinf=0.0, neginf=0.0)
         print("WARNING: Non-finite depth values present")
 
     depth_min = depth.min()


### PR DESCRIPTION
Having files with non-ASCII characters (e.g. "ü") lead to a core dump.

I don't know if this is the ideal way. It feels very scattered. But with those changes it worked for me with all filenames within the Docker environment.