### PR TITLE
Allow for Pytorch 2.0 JIT tracing and torch onnx conversion.

### DIFF
--- a/midas/backbones/utils.py
+++ b/midas/backbones/utils.py
@@ -100,8 +100,8 @@ def forward_adapted_unflatten(pretrained, x, function_name="forward_features"):
             2,
             torch.Size(
                 [
-                    h // pretrained.model.patch_size[1],
-                    w // pretrained.model.patch_size[0],
+                    h.item() // pretrained.model.patch_size[1],
+                    w.item() // pretrained.model.patch_size[0],
                 ]
             ),
         )


### PR DESCRIPTION
# Issue:

When creating ONNX file or Pytorch JIT trace, this utils file throws a type error, as the `torch.Size()` function expects an array of ints not torch tensors.

# Fix:
Extract int from torch tensor, using `.item()`func call.