### PR TITLE
Compatibility with latest timm and torch

### DIFF
--- a/midas/backbones/beit.py
+++ b/midas/backbones/beit.py
@@ -96,12 +96,12 @@ def block_forward(self, x, resolution, shared_rel_pos_bias: Optional[torch.Tenso
     Modification of timm.models.beit.py: Block.forward to support arbitrary window sizes.
     """
     if self.gamma_1 is None:
-        x = x + self.drop_path(self.attn(self.norm1(x), resolution, shared_rel_pos_bias=shared_rel_pos_bias))
-        x = x + self.drop_path(self.mlp(self.norm2(x)))
+        x = x + self.drop_path1(self.attn(self.norm1(x), resolution, shared_rel_pos_bias=shared_rel_pos_bias))
+        x = x + self.drop_path2(self.mlp(self.norm2(x)))
     else:
-        x = x + self.drop_path(self.gamma_1 * self.attn(self.norm1(x), resolution,
+        x = x + self.drop_path1(self.gamma_1 * self.attn(self.norm1(x), resolution,
                                                         shared_rel_pos_bias=shared_rel_pos_bias))
-        x = x + self.drop_path(self.gamma_2 * self.mlp(self.norm2(x)))
+        x = x + self.drop_path2(self.gamma_2 * self.mlp(self.norm2(x)))
     return x
 
 

--- a/midas/backbones/beit.py
+++ b/midas/backbones/beit.py
@@ -44,7 +44,7 @@ def _get_rel_pos_bias(self, window_size):
     old_sub_table = old_relative_position_bias_table[:old_num_relative_distance - 3]
 
     old_sub_table = old_sub_table.reshape(1, old_width, old_height, -1).permute(0, 3, 1, 2)
-    new_sub_table = F.interpolate(old_sub_table, size=(new_height, new_width), mode="bilinear")
+    new_sub_table = F.interpolate(old_sub_table, size=(int(new_height),int(new_width)), mode="bilinear")
     new_sub_table = new_sub_table.permute(0, 2, 3, 1).reshape(new_num_relative_distance - 3, -1)
 
     new_relative_position_bias_table = torch.cat(


### PR DESCRIPTION
### Torch Compatibility

We're working with the [latest nightly version](https://download.pytorch.org/whl/nightly/torch/) of torch. They seem to have added type asserts to interpolate [(this commit)](https://github.com/pytorch/pytorch/commit/6bda97e2c16fb35f743ff3fe292782d7ee082877).

This causes a runtime error because the size we pass in is of type `numpy.int32`. A simple int-cast should fix this without any side effects.

### Timm compatibility

`Blocks.drop_path()` was deprecated and replaced with `Blocks.drop_path1()` and `Blocks.drop_path2()` in [this commit](https://github.com/huggingface/pytorch-image-models/commit/3863d63516c99bbd7ade25fba88f030a40cd8e30#diff-23223719d678dae199e59ce099f5c28b814f8e6994288cffd291929cd9eb4c03). This has been causing a runtime error referenced in [this issue](https://github.com/isl-org/MiDaS/issues/215). 

This has affected things downstream in [ZoeDepth](https://github.com/isl-org/ZoeDepth/issues/26) and Auto1111's controlnet extension.