### PR TITLE
Fix TypeError: Tuple error

### DIFF
--- a/midas/backbones/beit.py
+++ b/midas/backbones/beit.py
@@ -44,7 +44,7 @@ def _get_rel_pos_bias(self, window_size):
     old_sub_table = old_relative_position_bias_table[:old_num_relative_distance - 3]
 
     old_sub_table = old_sub_table.reshape(1, old_width, old_height, -1).permute(0, 3, 1, 2)
-    new_sub_table = F.interpolate(old_sub_table, size=(new_height, new_width), mode="bilinear")
+    new_sub_table = F.interpolate(old_sub_table, size=(int(new_height), int(new_width)), mode="bilinear")
     new_sub_table = new_sub_table.permute(0, 2, 3, 1).reshape(new_num_relative_distance - 3, -1)
 
     new_relative_position_bias_table = torch.cat(


### PR DESCRIPTION
The error was occurring when the F.interpolate function was called with new_height and new_width as arguments for the size parameter. These variables were of type numpy.intc, while F.interpolate expected arguments of type int or Tuple[int] or Tuple[int, int] or Tuple[int, int, int].

The fix involves converting new_height and new_width to Python's native int type before they are passed to F.interpolate. This ensures that the function receives arguments of the correct type, preventing the TypeError.